### PR TITLE
Show avatar alone on white background

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ node_modules
 .DS_Store
 *.log
 dist
+.tsbuild
 .vscode
 .idea
 .env
+*.tsbuildinfo

--- a/index.html
+++ b/index.html
@@ -6,18 +6,9 @@
     <title>Simply Ben · Chapter One</title>
     <meta name="description" content="A playable point-and-click experiment by Ben Whitfield-Heap." />
     <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
-    <link rel="stylesheet" href="./style.css" />
   </head>
   <body>
-    <main class="chapter-one__frame">
-      <div class="chapter-one__content" data-chapter-content>
-        <button class="avatar-button" type="button" aria-describedby="avatar-instructions avatar-status">
-          <img src="img/avatar.jpg" alt="Portrait of Ben Whitfield-Heap" loading="lazy" />
-          <span id="avatar-instructions" class="sr-only">Tap or press the portrait until something changes.</span>
-          <span id="avatar-status" class="sr-only" aria-live="polite">You have tapped 0 times.</span>
-        </button>
-      </div>
-    </main>
-    <script type="module" src="./js/avatar-puzzle.js"></script>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/chapters/chapter1/ChapterOne.tsx
+++ b/src/chapters/chapter1/ChapterOne.tsx
@@ -1,86 +1,12 @@
 import { GameViewport } from '../../components/GameViewport';
-import { usePersistentState } from '../../hooks/usePersistentState';
 import { AvatarScene } from './components/AvatarScene';
-import { BlackoutScene } from './components/BlackoutScene';
-import { TorchScene } from './components/TorchScene';
-
-type ChapterOneStage = 'avatar' | 'blackout' | 'torch';
-
-interface ChapterOneProgress {
-  stage: ChapterOneStage;
-  avatarClicks: number;
-  blackoutClicks: number;
-}
-
-const STORAGE_KEY = 'chapter1_state';
-const AVATAR_REQUIRED = 5;
-const BLACKOUT_REQUIRED = 9;
-
-const createInitialState = (): ChapterOneProgress => ({
-  stage: 'avatar',
-  avatarClicks: 0,
-  blackoutClicks: 0,
-});
 
 export function ChapterOne() {
-  const [progress, setProgress] = usePersistentState<ChapterOneProgress>(STORAGE_KEY, createInitialState);
-
-  const goToStage = (stage: ChapterOneStage, overrides?: Partial<ChapterOneProgress>) => {
-    setProgress((current) => ({
-      ...current,
-      ...(overrides ?? {}),
-      stage,
-    }));
-  };
-
-  const handleAvatarPress = () => {
-    if (progress.stage !== 'avatar') {
-      return;
-    }
-
-    const nextCount = progress.avatarClicks + 1;
-    if (nextCount >= AVATAR_REQUIRED) {
-      goToStage('blackout', { avatarClicks: nextCount, blackoutClicks: progress.blackoutClicks });
-      return;
-    }
-
-    setProgress({ ...progress, avatarClicks: nextCount });
-  };
-
-  const handleBlackoutPress = () => {
-    if (progress.stage !== 'blackout') {
-      return;
-    }
-
-    const nextCount = progress.blackoutClicks + 1;
-    if (nextCount >= BLACKOUT_REQUIRED) {
-      goToStage('torch', { blackoutClicks: nextCount });
-      return;
-    }
-
-    setProgress({ ...progress, blackoutClicks: nextCount });
-  };
-
-  const resetChapter = () => {
-    setProgress(createInitialState());
-  };
-
   return (
-    <GameViewport accent={progress.stage === 'torch' ? 'void' : 'warm'}>
-      <section className={`chapter-one chapter-one--${progress.stage}`}>
-        <div className="chapter-one__hud">
-          <button type="button" className="hud-button" onClick={resetChapter}>
-            Reset memory
-          </button>
-        </div>
+    <GameViewport accent="warm">
+      <section className="chapter-one chapter-one--avatar">
         <div className="chapter-one__content" aria-live="polite">
-          {progress.stage === 'avatar' && (
-            <AvatarScene onPress={handleAvatarPress} presses={progress.avatarClicks} required={AVATAR_REQUIRED} />
-          )}
-          {progress.stage === 'blackout' && (
-            <BlackoutScene onPress={handleBlackoutPress} presses={progress.blackoutClicks} required={BLACKOUT_REQUIRED} />
-          )}
-          {progress.stage === 'torch' && <TorchScene />}
+          <AvatarScene />
         </div>
       </section>
     </GameViewport>

--- a/src/chapters/chapter1/components/AvatarScene.tsx
+++ b/src/chapters/chapter1/components/AvatarScene.tsx
@@ -1,59 +1,21 @@
-const avatarSvg = `
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
-    <defs>
-      <linearGradient id="portraitGlow" x1="0%" y1="0%" x2="100%" y2="100%">
-        <stop offset="0%" stop-color="#f5f0d8" />
-        <stop offset="50%" stop-color="#ffe4a8" />
-        <stop offset="100%" stop-color="#d2c4ff" />
-      </linearGradient>
-    </defs>
-    <rect width="200" height="200" rx="28" fill="#050505" />
-    <circle cx="100" cy="92" r="56" fill="url(#portraitGlow)" opacity="0.75" />
-    <path
-      d="M60 150 C80 124 120 124 140 150 L140 170 L60 170 Z"
-      fill="#101010"
-      stroke="#f5f0d8"
-      stroke-width="3"
-      opacity="0.85"
-    />
-    <circle cx="78" cy="96" r="6" fill="#050505" />
-    <circle cx="122" cy="96" r="6" fill="#050505" />
-    <path d="M80 120 Q100 132 120 120" fill="none" stroke="#050505" stroke-width="4" stroke-linecap="round" />
-  </svg>
-`;
-
-const avatarPortrait = `data:image/svg+xml;utf8,${encodeURIComponent(avatarSvg)}`;
+import avatarPortrait from '../../../../img/avatar.jpg';
 
 type AvatarSceneProps = {
-  onPress: () => void;
-  presses: number;
-  required: number;
+  onPress?: () => void;
 };
 
-export function AvatarScene({ onPress, presses, required }: AvatarSceneProps) {
-  const remaining = Math.max(required - presses, 0);
-  const statusMessage =
-    remaining > 0
-      ? `You have tapped ${presses} of ${required} times.`
-      : 'The avatar stops resisting. The light collapses.';
-
+export function AvatarScene({ onPress }: AvatarSceneProps = {}) {
   return (
-    <>
-      <button
-        type="button"
-        className="avatar-scene__button"
-        onClick={onPress}
-        aria-describedby="avatar-instructions avatar-status"
-      >
-        <img src={avatarPortrait} alt="A portrait, perfectly still." loading="lazy" />
-        <span id="avatar-instructions" className="sr-only">
-          Tap or press the portrait until the silence breaks. Pointer, touch, keyboard—all are welcome.
-        </span>
-        <span id="avatar-status" className="sr-only" aria-live="polite">
-          {statusMessage}
-        </span>
-      </button>
-      <p className="avatar-scene__whisper">The static hums. {remaining ? 'Keep insisting.' : 'The hum dies.'}</p>
-    </>
+    <button
+      type="button"
+      className="avatar-scene__button"
+      onClick={onPress}
+      aria-describedby="avatar-instructions"
+    >
+      <img src={avatarPortrait} alt="A portrait." loading="lazy" />
+      <span id="avatar-instructions" className="sr-only">
+        Tap or press the portrait.
+      </span>
+    </button>
   );
 }

--- a/src/chapters/chapter1/components/TorchScene.tsx
+++ b/src/chapters/chapter1/components/TorchScene.tsx
@@ -64,11 +64,12 @@ export function TorchScene() {
     });
   };
 
-  const overlayStyle: CSSProperties = {
-    ['--torch-x' as '--torch-x']: `${torchPosition.x}%`,
-    ['--torch-y' as '--torch-y']: `${torchPosition.y}%`,
-    ['--torch-radius' as '--torch-radius']: 'clamp(120px, 20vmin, 320px)',
-  };
+  const overlayStyle: CSSProperties &
+    Record<'--torch-x' | '--torch-y' | '--torch-radius', string> = {
+      '--torch-x': `${torchPosition.x}%`,
+      '--torch-y': `${torchPosition.y}%`,
+      '--torch-radius': 'clamp(120px, 20vmin, 320px)',
+    };
 
   return (
     <div

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,11 +1,11 @@
 :root {
   font-family: 'Space Grotesk', 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
-  color-scheme: dark;
-  --ink: #f6f4f1;
-  --muted: rgba(255, 255, 255, 0.72);
-  --glow: rgba(255, 186, 99, 0.35);
+  color-scheme: light;
+  --ink: #101010;
+  --muted: #4f4f4f;
+  --glow: rgba(255, 186, 99, 0.15);
   --accent: #ff8d3d;
-  --accent-strong: #ffd155;
+  --accent-strong: #ffb155;
   --void: #050505;
   --focus: #5cf7ff;
 }
@@ -19,7 +19,7 @@ body {
   min-height: 100vh;
   font-family: var(--font-body, 'Space Grotesk', 'Inter', sans-serif);
   line-height: 1.5;
-  background: radial-gradient(circle at 15% 25%, #1c1638, #05030b 68%);
+  background: #ffffff;
   color: var(--ink);
   overflow: hidden;
 }
@@ -40,23 +40,23 @@ body {
   width: min(1100px, 96vw);
   aspect-ratio: 16 / 9;
   border-radius: clamp(18px, 2vw, 32px);
-  border: 1px solid rgba(255, 255, 255, 0.18);
+  border: 1px solid rgba(0, 0, 0, 0.05);
   overflow: hidden;
   position: relative;
-  box-shadow: 0 30px 90px rgba(0, 0, 0, 0.65);
-  background: #05050b;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.1);
+  background: #ffffff;
 }
 
 .game-shell--warm {
-  background: radial-gradient(circle at 30% 20%, rgba(255, 255, 255, 0.08), rgba(5, 5, 10, 0.95));
+  background: #ffffff;
 }
 
 .game-shell--cold {
-  background: radial-gradient(circle at 70% 30%, rgba(102, 237, 255, 0.08), rgba(4, 8, 16, 0.98));
+  background: #ffffff;
 }
 
 .game-shell--void {
-  background: radial-gradient(circle at 70% 10%, rgba(255, 255, 255, 0.06), rgba(2, 2, 2, 0.98));
+  background: #ffffff;
 }
 
 .chapter-one,
@@ -125,7 +125,7 @@ body {
   align-items: center;
   justify-content: center;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 0;
   text-align: center;
   padding: clamp(1.5rem, 4vw, 3rem);
 }
@@ -135,11 +135,11 @@ body {
   background: transparent;
   padding: 0;
   border-radius: 50%;
-  width: min(60vmin, 380px);
+  width: clamp(140px, 48vw, 220px);
   aspect-ratio: 1 / 1;
   cursor: pointer;
   position: relative;
-  box-shadow: 0 25px 70px rgba(0, 0, 0, 0.6);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.12);
   transition: transform 200ms ease, box-shadow 200ms ease;
 }
 
@@ -148,8 +148,8 @@ body {
   height: 100%;
   border-radius: 50%;
   object-fit: cover;
-  border: clamp(10px, 2vw, 14px) solid rgba(255, 255, 255, 0.85);
-  filter: saturate(0.96);
+  border: clamp(8px, 2vw, 12px) solid rgba(0, 0, 0, 0.04);
+  filter: saturate(0.98);
   transition: transform 400ms ease, filter 400ms ease;
 }
 
@@ -169,10 +169,7 @@ body {
 }
 
 .avatar-scene__whisper {
-  font-size: 0.95rem;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.6);
+  display: none;
 }
 
 .blackout-scene {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "ESNext",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "skipLibCheck": true,
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "strict": true,

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -2,9 +2,10 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "allowSyntheticDefaultImports": true,
-    "types": ["node"]
+    "types": ["node"],
+    "outDir": "./.tsbuild"
   },
   "include": ["vite.config.ts"]
 }


### PR DESCRIPTION
## Summary
- render only the avatar portrait without the previous HUD, text, or alternate scenes
- size the portrait as a mobile-friendly tap target with softer framing
- switch the layout to a clean white background for a minimal presentation

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f6886e9f88321b0fd8196284c223c)