### PR TITLE
Fix asset base path for deep links

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,8 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
-  base: './',
+  // Use absolute asset paths so deep links (e.g. /lead) still find the bundle
+  // when the static host rewrites to index.html.
+  base: '/',
   plugins: [react()],
 });


### PR DESCRIPTION
## Summary
- use an absolute Vite base path so bundles load correctly from deep links

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f7f2d9c388321902ed6e233d86a7e)